### PR TITLE
chore(migrate): prep PR for nexus-substrate org transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nexus-toolkit
 
-E2E test suite for [nexus-agents](https://github.com/williamzujkowski/nexus-agents) MCP tools: **orchestrate**, **research_catalog_review**, and **registry_import**.
+E2E test suite for [nexus-agents](https://github.com/nexus-substrate/nexus-agents) MCP tools: **orchestrate**, **research_catalog_review**, and **registry_import**.
 
 ## What it tests
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/williamzujkowski/nexus-toolkit.git"
+    "url": "https://github.com/nexus-substrate/nexus-toolkit.git"
   },
   "keywords": [
     "nexus-agents",


### PR DESCRIPTION
Part of nexus-substrate/nexus-agents#2831 (epic). Addresses #6.

Updates `package.json` `repository.url` and README link to point at `nexus-substrate/nexus-agents`. Pre-transfer sweep so the repo lands at the new owner already self-consistent.

## Post-merge

- [ ] `gh api -X POST repos/williamzujkowski/nexus-toolkit/transfer -f new_owner=nexus-substrate`
- [ ] Re-bootstrap npm trusted publisher for `nexus-toolkit` at https://www.npmjs.com/package/nexus-toolkit/access

🤖 Generated with [Claude Code](https://claude.com/claude-code)