### PR TITLE
fix: move zod from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,10 +43,12 @@
     "tsx": "^4.19.0",
     "typescript": "^5.9.0",
     "vitest": "^3.2.0",
-    "zod": "^3.24.0",
     "@types/node": "^22.0.0"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "zod": "^3.24.0"
   }
 }


### PR DESCRIPTION
## Problem

`src/types.ts` imports `z from 'zod'`, and the compiled `dist/index.js` requires zod at runtime. But `package.json` declares zod only under `devDependencies`.

Downstream consumers running `npm install nexus-toolkit` and importing the Zod schemas would hit a missing-module error.

Fixes #11

## Fix

Move `zod` from `devDependencies` to `dependencies` in `package.json`.
