### PR TITLE
fix: escape markdown report table cells

### DIFF
--- a/src/reporter.test.ts
+++ b/src/reporter.test.ts
@@ -46,6 +46,26 @@ describe('generateReport', () => {
     it('defaults to markdown', () => {
       expect(generateReport(SAMPLE_AUDIT)).toContain('# Toolkit Audit');
     });
+
+    it('escapes markdown table separators in tool and error cells', () => {
+      const report = generateReport({
+        results: [
+          {
+            tool: 'registry|import',
+            status: 'fail',
+            error: 'Schema mismatch: expected foo|bar\nreceived baz',
+            durationMs: 100,
+          },
+        ],
+        passed: 0,
+        failed: 1,
+        skipped: 0,
+      });
+
+      expect(report).toContain(
+        '| registry\\|import | fail | 100ms | Schema mismatch: expected foo\\|bar received baz |',
+      );
+    });
   });
 
   describe('json', () => {

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -38,6 +38,10 @@ function formatText(a: ToolkitAudit): string {
   return lines.join('\n');
 }
 
+function markdownCell(value: string): string {
+  return value.replace(/\r?\n/g, ' ').replace(/\|/g, '\\|');
+}
+
 function formatMarkdown(a: ToolkitAudit): string {
   const lines = [
     '# Toolkit Audit',
@@ -56,8 +60,8 @@ function formatMarkdown(a: ToolkitAudit): string {
     '| --- | --- | --- | --- |',
   ];
   for (const r of a.results) {
-    const err = r.error ?? '';
-    lines.push(`| ${r.tool} | ${r.status} | ${r.durationMs}ms | ${err} |`);
+    const err = markdownCell(r.error ?? '');
+    lines.push(`| ${markdownCell(r.tool)} | ${r.status} | ${r.durationMs}ms | ${err} |`);
   }
   return lines.join('\n');
 }


### PR DESCRIPTION
## Summary
- escape `|` characters in markdown report table cells
- collapse newlines in markdown cells so errors stay on one table row
- add a regression test covering both tool and error cells

## Why
`formatMarkdown()` interpolated tool names and error messages directly into a markdown table. Error strings containing pipes could split the row into extra columns and corrupt the rendered report.

Fixes #12.

## Checks
- `pnpm install --frozen-lockfile`
- `pnpm test -- src/reporter.test.ts` (`59` tests passing)
- `pnpm test` (`59` tests passing)
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`
